### PR TITLE
Prevent Windows from watching root path on Windows due to case sensitive matching

### DIFF
--- a/lib/caching-browserify.js
+++ b/lib/caching-browserify.js
@@ -145,10 +145,15 @@ module.exports = CoreObject.extend({
   watchNodeModules: function(readTree) {
     var self = this;
     return mapSeries(Object.keys(self._watchModules), function(dir){
-      if (dir !== self.root){
+      if (self.normalizePath(dir) !== self.normalizePath(self.root)){
         return readTree(dir);
       }
     });
+  },
+
+  // Changes path drive-letter to lowercase for Windows
+  normalizePath: function(path) {
+    return (path && path.match(/^[a-z]:\\/i)) ? path.charAt(0).toLowerCase() + path.slice(1) : path;
   },
 
   // Due to the way CJS dependencies work, the appearance of a new


### PR DESCRIPTION
Fixes #17.

I've opted for a minimally intrusive approach here just correcting the problem specific to Windows drive letters. Another simpler option would be to call `.toLowerCase()` on both strings but may have unintended side-effects on case-sensitive drive systems.
