### PR TITLE
quote `default` key, breaks on browsers with reserved keywords

### DIFF
--- a/lib/stub-generator.js
+++ b/lib/stub-generator.js
@@ -76,7 +76,7 @@ function generate(stubs) {
   return Object.keys(stubs).map(function(moduleName){
     return "define('npm:" +
       moduleName +
-      "', function(){ return { default: require('" +
+      "', function(){ return { 'default': require('" +
       moduleName +
       "')};})";
   }).join("\n");


### PR DESCRIPTION
Makes it play nice with IE8+, which throws an error because default is a reserved keyword