### PR TITLE
Temp solution to support addon consumption

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,12 @@ module.exports = {
   name: 'ember-browserify',
 
   included: function(app){
+    // Stop-gap measure to support another addon
+    // consuming this addon. https://github.com/ef4/ember-browserify/issues/29
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
+
     var enableSourcemaps = app.options.sourcemaps && app.options.sourcemaps.enabled && app.options.sourcemaps.extensions.indexOf('js') > -1;
 
     this.app = app;


### PR DESCRIPTION
Temporary workaround to allow an addon to directly use embor-browserify.
https://github.com/ef4/ember-browserify/issues/29