### PR TITLE
Add dependencies during tests via config param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ module.exports = {
     };
 
     app.import('browserify/browserify.js');
-    if (app.tests && process.env.BROWSERIFY_TESTS) {
+    if (app.tests && this.options.browserifyOptions.tests) {
       app.import('browserify-tests/browserify.js');
     }
 


### PR DESCRIPTION
This is **not** a fix for #14. 

Minor change to facilitate ember-cli builds via `environment.js` rather than using `BROWSERIFY_TESTS`.