### PR TITLE
Use acorn instead of esprima

### DIFF
--- a/lib/stub-generator.js
+++ b/lib/stub-generator.js
@@ -1,5 +1,5 @@
 var walkSync = require('walk-sync');
-var esprima = require('esprima');
+var acorn = require('acorn');
 var fs = require('fs');
 var helpers = require('broccoli-kitchen-sink-helpers');
 var RSVP = require('rsvp');
@@ -113,7 +113,11 @@ function forEachNode(node, visit) {
 
 function parseImports(src) {
   var imports = {};
-  forEachNode(esprima.parse(src), function(entry) {
+  var ast = acorn.parse(src, {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  });
+  forEachNode(ast, function(entry) {
     if (entry.type === 'ImportDeclaration') {
       var source = entry.source.value;
       if (source.slice(0,4) === 'npm:') {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "browserify": "^9.0.3",
     "core-object": "0.0.4",
-    "esprima": "git://github.com/esnext/esprima#harmony-esnext",
+    "acorn": "1.1.0",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "promise-map-series": "^0.2.0",


### PR DESCRIPTION
Acorn is faster. Acorn also does not make git requests during build, which Esprima does. This is unpaletable for many companies that don't want out-of-datacenter network calls at build time.

http://esprima.org/test/compare.html
http://marijnhaverbeke.nl/blog/acorn.html