### PR TITLE
Safely traverse codebases with circular AST

### DIFF
--- a/lib/stub-generator.js
+++ b/lib/stub-generator.js
@@ -102,7 +102,8 @@ function sameStubs(a, b) {
 }
 
 function forEachNode(node, visit) {
-  if (node && typeof node === 'object') {
+  if (node && typeof node === 'object' && !node._eb_visited) {
+    node._eb_visited = true;
     visit(node);
     var keys = Object.keys(node);
     for (var i=0; i < keys.length; i++) {


### PR DESCRIPTION
Apparently an AST object can be circular, in which case we need some check for loops.