### PR TITLE
PostProccess No Longer Receives Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ browserify: {
 }
 ```
 
+## Known Caveats
+
+Ember-browserify __cannot__ be used with named imports e.g. `import { foo } from 'bar';` as we have no way of knowing at the time of browserifying what portions of the import are being used.
+
 ## Using ember-browserify in addons
 
 Wrapping generic npm libraries is a pretty common use case for ember addons. Unfortunately, ember-browserify installed on an addon cannot simply consume an npm dependency for the host app. This is a limitation of ember-cli. More info in [this issue](https://github.com/ef4/ember-browserify/issues/34) and [this issue](https://github.com/ef4/ember-browserify/issues/38). Try it, and you'll probably get this error:

--- a/lib/stub-generator.js
+++ b/lib/stub-generator.js
@@ -114,20 +114,23 @@ function forEachNode(node, visit) {
 
 function parseImports(src) {
   var imports = {};
-  var ast = acorn.parse(src, {
-    ecmaVersion: 6,
-    sourceType: 'module'
-  });
+  var ast = acorn.parse(src);
+
   forEachNode(ast, function(entry) {
-    if (entry.type === 'ImportDeclaration') {
-      var source = entry.source.value;
-      if (source.slice(0,4) === 'npm:') {
-        if (entry.kind === 'named') {
-          throw new Error("ember-browserify doesn't support named imports (you tried to import " + entry.specifiers[0].id.name +  " from " + source);
-        }
-        imports[source.slice(4)] = true;
-      }
+    if (entry.type === 'CallExpression' && entry.callee.name === 'define') {
+      head(entry.arguments.filter(function(item) {
+        return item.type === 'ArrayExpression';
+      })).elements.filter(function(element) {
+        return element.value.slice(0, 4) === 'npm:';
+      }).forEach(function(element) {
+        imports[element.value.slice(4)] = true;
+      });
     }
   });
+
   return imports;
+}
+
+function head(array) {
+  return array[0];
 }

--- a/test/fixtures/stubs/inner/other.js
+++ b/test/fixtures/stubs/inner/other.js
@@ -1,2 +1,3 @@
-import X from "npm:x";
-import "npm:y";
+define('foo', ['exports', 'npm:x', 'npm:y'], function(exports, _npmX, _npmY) {
+
+});

--- a/test/fixtures/stubs/sample.js
+++ b/test/fixtures/stubs/sample.js
@@ -1,2 +1,3 @@
-import Broccoli from "npm:broccoli";
-export default Broccoli;
+define('foo', ['exports', 'npm:broccoli'], function(exports, Broccoli) {
+  exports['default'] = Broccoli;
+});

--- a/test/test.js
+++ b/test/test.js
@@ -48,7 +48,7 @@ describe('Stub Generator', function() {
     builder = new broccoli.Builder(tree);
     return builder.build().then(function(result) {
       expectFile('browserify_stubs.js').toMatch('first.js').in(result);
-      fs.writeFileSync(path.join(src.inputTree, 'new.js'), "import SomethingNew from \"npm:something-new\"\n");
+      fs.writeFileSync(path.join(src.inputTree, 'new.js'), "define(\"fizz\", [\"exports\", \"npm:something-new\"], function(exports, SomethingNew) {});");
       return builder.build();
     }).then(function(result){
       expectFile('browserify_stubs.js').toMatch('second.js').in(result);
@@ -72,8 +72,8 @@ describe('Stub Generator', function() {
     builder = new broccoli.Builder(tree);
     return builder.build().then(function(result) {
       expectFile('browserify_stubs.js').toMatch('first.js').in(result);
-      var was = fs.readFileSync(path.join(src.inputTree, 'sample.js'));
-      was += "\nimport Additional from 'npm:additional-thing';";
+      var was = "define('foo', ['exports', 'npm:broccoli', 'npm:additional-thing'], function(exports, Broccoli, Additional) { exports['default'] = Broccoli;});";
+
       fs.writeFileSync(path.join(src.inputTree, 'sample.js'), was);
       return builder.build();
     }).then(function(result){
@@ -86,8 +86,8 @@ describe('Stub Generator', function() {
     builder = new broccoli.Builder(tree);
     return builder.build().then(function(result) {
       expectFile('browserify_stubs.js').toMatch('first.js').in(result);
-      var was = fs.readFileSync(path.join(src.inputTree, 'inner', 'other.js'), 'utf-8');
-      was = was.split("\n").slice(1).join("\n");
+      var was = "define('foo', ['exports', 'npm:y'], function(exports, _npmY) {});";
+
       fs.writeFileSync(path.join(src.inputTree, 'inner', 'other.js'), was);
       return builder.build();
     }).then(function(result){


### PR DESCRIPTION
We will be removing esperanto and slightly modify the flow of trees.
PostProcess hook will now recieve a fully preprocessed tree instead of
one that was only partially processed.

While these changes have been verfiied in a real app, we loose the
ability to throw when a dev attempts to use a named import.

Please see https://github.com/ember-cli/ember-cli/pull/4764 for more details about the changes that effect this addon.