### PR TITLE
Use latest API for importing to test tree

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,8 @@ module.exports = {
 
     app.import('browserify/browserify.js');
     if (app.tests && (process.env.BROWSERIFY_TESTS || this.options.browserifyOptions.tests)) {
-      app.import({
-        test: 'browserify-tests/browserify.js'
+      app.import('browserify-tests/browserify.js', {
+        type: 'test' 
       });
     }
 


### PR DESCRIPTION
Use the `app.import()` [options API](https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/ember-app.js#L1274) to declare that the test stubs file should be added to the test tree.