### PR TITLE
Fix bug caused by updated app.import API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,19 @@
 var StubGenerator = require('./stub-generator');
 var CachingBrowserify = require('./caching-browserify');
 var mergeTrees = require('broccoli-merge-trees');
+var semver = require('semver');
 
 module.exports = {
   name: 'ember-browserify',
 
   included: function(app){
+    var appPackage = app.project.pkg;
+    var deps = appPackage.dependencies || {};
+    var devDeps = appPackage.devDependencies || {};
+    var emberCliVersion = devDeps['ember-cli'] || deps['ember-cli'];
+
+    var newImportApi = semver.gt(emberCliVersion, '1.13.8');
+
     // Stop-gap measure to support another addon
     // consuming this addon. https://github.com/ef4/ember-browserify/issues/29
     if (typeof app.import !== 'function' && app.app) {
@@ -25,9 +33,15 @@ module.exports = {
 
     app.import('browserify/browserify.js');
     if (app.tests && (process.env.BROWSERIFY_TESTS || this.options.browserifyOptions.tests)) {
-      app.import({
-        test: 'browserify-tests/browserify.js'
-      });
+      if (newImportApi) {
+        app.import('browserify-tests/browserify.js', {
+          type: 'test'
+        });
+      } else {
+        app.import({
+          test: 'browserify-tests/browserify.js'
+        });
+      }
     }
 
     if (app.importWhitelistFilters) {

--- a/package.json
+++ b/package.json
@@ -29,18 +29,19 @@
     "sinon-chai": "^2.6.0"
   },
   "dependencies": {
+    "acorn": "2.3.0",
     "broccoli-caching-writer": "^2.0.1",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "broccoli-merge-trees": "^0.2.1",
     "browserify": "^9.0.3",
     "core-object": "0.0.4",
-    "acorn": "2.3.0",
     "lodash-node": "^2.4.1",
     "mkdirp": "^0.5.0",
     "promise-map-series": "^0.2.0",
     "quick-temp": "^0.1.2",
     "rimraf": "^2.2.8",
     "rsvp": "^3.0.14",
+    "semver": "^5.0.3",
     "symlink-or-copy": "^1.0.0",
     "walk-sync": "^0.1.3"
   }


### PR DESCRIPTION
Addresses https://github.com/ef4/ember-browserify/issues/53.

The ember-cli `app.import` API changes from 1.13.8 > 1.13.11