### PR TITLE
Prevent watching parent directories of project root

### DIFF
--- a/lib/caching-browserify.js
+++ b/lib/caching-browserify.js
@@ -190,8 +190,10 @@ module.exports = CoreObject.extend({
 
   watchNodeModules: function(readTree) {
     var self = this;
+    var root = self.normalizePath(self.root);
+
     return mapSeries(Object.keys(self._watchModules), function(dir){
-      if (self.normalizePath(dir) !== self.normalizePath(self.root)){
+      if (!root || root.indexOf(self.normalizePath(dir)) !== 0){
         return readTree(dir);
       }
     });


### PR DESCRIPTION
In working on a custom task that builds an Ember project from outside its root directory, I was getting infinite rebuilds while using this addon. The root cause is that the process' `cwd` is different from the project's `root`, which meant that it wound up getting "watched". Since the project is a child of this watched directory, it would rebuild anytime anything changed.

I propose to fix this issue by making sure that the watched dir is not equal to or a starting portion of the project's root.

cc @asakusuma 