### PR TITLE
Upgrade browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-kitchen-sink-helpers": "^0.2.5",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-plugin": "^1.2.1",
-    "browserify": "^9.0.3",
+    "browserify": "^13.0.0",
     "core-object": "^1.1.0",
     "debug": "^2.2.0",
     "derequire": "^2.0.3",

--- a/test/test.js
+++ b/test/test.js
@@ -473,7 +473,9 @@ describe('CachingBrowserify', function() {
       var module = path.resolve(__dirname + '/../node_modules/my-module');
       var target = module + '/index.js';
 
-      expect(readTrees).to.contain.key(module);
+      expect(Object.keys(readTrees).filter(function(readTree) {
+          return /my-module/.test(readTree);
+      }), 'expected readTrees to contain a path that matched `/node_modules\/my-module/`').to.not.be.empty;
 
       var code = fs.readFileSync(target, 'utf-8');
       code = code.replace('other.something()', 'other.something()+1');


### PR DESCRIPTION
depends on https://github.com/ef4/ember-browserify/pull/82, will rebase once that lands. The commit in question is:

* https://github.com/ef4/ember-browserify/commit/0c9096fc11f390e1d8e0de5d8dc651d12467ea93

fixes:
* #77