### PR TITLE
Ensure StubGenerator subclasses correctly

### DIFF
--- a/lib/stub-generator.js
+++ b/lib/stub-generator.js
@@ -27,6 +27,7 @@ function StubGenerator(inputTree, options) {
 }
 
 StubGenerator.prototype = Object.create(Plugin.prototype);
+StubGenerator.prototype.constructor = StubGenerator;
 StubGenerator.prototype.build = function() {
   var start = Date.now();
   var inputPath = this.inputPaths[0];


### PR DESCRIPTION
* fixes instrumentation, which incorrectly named StuGenerator as “Plugin” (it’s ancestor)