### PR TITLE
Update "temporary" stop-gap for supporting nested addons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
 
     // Stop-gap measure to support another addon
     // consuming this addon. https://github.com/ef4/ember-browserify/issues/29
-    if (typeof app.import !== 'function' && app.app) {
+    if (!app.options && app.app && app.app.options) {
       app = app.app;
     }
 


### PR DESCRIPTION
When upgrading to 2.7.0, I'm seeing the "sourcemaps not defined" issue again. It seems that the previous stopgap wasn't as future-proof as we'd like it to be. :)

I've switched from duck-typing against `app.import` to `app.options`, since that's the accessor that fails every time this bug resurfaces.

Here's the previous PR: https://github.com/ef4/ember-browserify/pull/30/files