### PR TITLE
Removes redundant check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
 
     // Stop-gap measure to support another addon
     // consuming this addon. https://github.com/ef4/ember-browserify/issues/29
-    if (typeof app.import !== 'function' && app.app) {
+    if (app.app) {
       app = app.app;
     }
 


### PR DESCRIPTION
Some of the child addons (the ones that consume `ember-browserify`) start breaking after upgrading to `2.7.0`. This fixes failures.