### PR TITLE
Support hoisting to nearest host.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,19 @@
+// Support old versions of Ember CLI.
+function findHost() {
+  var current = this;
+  var app;
+
+  // Keep iterating upward until we don't have a grandparent.
+  // Has to do this grandparent check because at some point we hit the project.
+  // Stop at lazy engine boundaries.
+  do {
+    if (current.lazyLoading === true) { return current; }
+    app = current.app || app;
+  } while (current.parent && current.parent.parent && (current = current.parent));
+
+  return app;
+}
+
 module.exports = {
   name: 'ember-browserify',
 
@@ -12,11 +28,7 @@ module.exports = {
       newImportApi = true;
     }
 
-    // Stop-gap measure to support another addon
-    // consuming this addon. https://github.com/ef4/ember-browserify/issues/29
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
+    app = findHost.call(this);
 
     var enableSourcemaps = app.options.sourcemaps && app.options.sourcemaps.enabled && app.options.sourcemaps.extensions.indexOf('js') > -1;
 


### PR DESCRIPTION
ember-browserify currently does a one-level deep check in an attempt to find the host application, making it work in addons which directly descend from the host. This is incomplete. Addons can be nested infinitely deep and we need to recurse up to the host.

This code is extracted from Ember CLI.

Except for the one line added by ember-engines since the host is not always guaranteed to be the top level application. The host may _also_ be the closest lazily-loaded engine.

This code is identical to the check which ember-engines uses to support importing.

Closes #92 and #93.