### PR TITLE
Allow fullPaths to be configurable from the consuming app

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,14 +31,15 @@ module.exports = {
     app = findHost.call(this);
 
     var enableSourcemaps = app.options.sourcemaps && app.options.sourcemaps.enabled && app.options.sourcemaps.extensions.indexOf('js') > -1;
+    var customConfig = app.project.config(app.env).browserify || {};
 
     this.app = app;
 
     this.options = {
       root: this.app.project.root,
-      browserifyOptions: app.project.config(app.env).browserify || {},
+      browserifyOptions: customConfig,
       enableSourcemap: enableSourcemaps,
-      fullPaths: app.env !== 'production'
+      fullPaths: (customConfig.fullPaths === undefined) ? (app.env !== 'production') : customConfig.fullPaths
     };
 
     app.import('browserify/browserify.js');


### PR DESCRIPTION
This PR solves the lack of configurability of `fullPaths` to support other production-like deployment environments, like `staging`.

See https://github.com/ef4/ember-browserify/issues/107
