### PR TITLE
Ignore `browser` field when running with Fastboot

### DIFF
--- a/lib/caching-browserify.js
+++ b/lib/caching-browserify.js
@@ -95,7 +95,8 @@ module.exports = CoreObject.extend({
       packageCache: {},
       fullPaths: this.fullPaths,
       basedir: this._inputStaging,
-      debug: this.enableSourcemap
+      debug: this.enableSourcemap,
+      browserField: !process.env.EMBER_CLI_FASTBOOT
     }, this.browserifyOptions);
 
     var b = browserify(opts);


### PR DESCRIPTION
Fixes #114 

This seems to pull in the correct (non-browser) code under Fastboot, but causes an error `TypeError: _ObjectImportedWithRequire.default is not a constructor`. Shouldn't be merged until I've sorted out why that's happening.