### PR TITLE
Changing error message on invalid syntax

### DIFF
--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -72,7 +72,7 @@ function importsFor(src, fullPath) {
 
   // If result is still an error, there must have been a parse error
   if (result instanceof Error) {
-    throw new Error('Error parsing code while looking for "npm:" imports: ' + result.stack || result + ' in file: ' + fullPath);
+    throw new Error('Error parsing code while looking for "npm:" imports: ' + (result.stack || result) + ' in file: ' + fullPath);
   }
 
   return result;


### PR DESCRIPTION
I noticed a bug when a file has invalid syntax. Ember-browserify throws the error `Error parsing code while looking for "npm:" imports: <Error Message>` but does not include a file path. I tracked it down to a simple precedence bug. After the fix the error message is correctly `Error parsing code while looking for "npm:" imports: <Error Message> in file: <Path>`

For my particular setup this means that I have to search through all of the files in the repo looking for a syntax error because the only error I get during the build is from the browserify plugin, so this can be an important issue.

As a side note - this bug also exists in both outstanding PRs and will cause merge conflicts with both of them.