### PR TITLE
update ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "core-object": "^1.1.0",
     "debug": "^2.2.0",
     "derequire": "^2.0.3",
-    "ember-cli-version-checker": "^1.1.4",
+    "ember-cli-version-checker": "^2.1.0",
     "fs-tree": "^1.0.0",
     "fs-tree-diff": "^0.5.0",
     "lodash": "^4.5.1",


### PR DESCRIPTION
Updating this package to remove a deprecation warning.

https://github.com/ember-cli/ember-cli-version-checker/issues/48