### PR TITLE
Add full path to errors with stack traces

### DIFF
--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -64,7 +64,7 @@ function importsFor(src, fullPath) {
   try {
     return parseModule(src);
   } catch (error) {
-    throw new Error('Error parsing code while looking for "npm:" imports: ' + error.stack || error + ' in file: ' + fullPath);
+    throw new Error('Error parsing code while looking for "npm:" imports in file: ' + fullPath + ' ' + error.stack || error);
   }
 }
 

--- a/lib/stubs.js
+++ b/lib/stubs.js
@@ -64,7 +64,7 @@ function importsFor(src, fullPath) {
   try {
     return parseModule(src);
   } catch (error) {
-    throw new Error('Error parsing code while looking for "npm:" imports in file: ' + fullPath + ' ' + error.stack || error);
+    throw new Error('Error parsing code while looking for "npm:" imports in file: ' + fullPath + '\n' + error.stack || error);
   }
 }
 


### PR DESCRIPTION
Related issue: https://github.com/ef4/ember-browserify/issues/121

In trying to reproduce the error above, it was unclear what import was causing this failure and it turned out it was happening in a file that didn't have an npm import at all. This should make it easier to identify the source of errors in the future.

Before:
```
The Broccoli Plugin: [object Object] failed with:
Error: Error parsing code while looking for "npm:" imports: TypeError: Cannot read property 'elements' of undefined
    at findAMDImports (/Users/bryan/dev/betterup-app/frontend/node_modules/ember-browserify/lib/stubs.js:114:6)
```

After:
```
The Broccoli Plugin: [object Object] failed with:
Error: Error parsing code while looking for "npm:" imports in file: /Users/bryan/dev/betterup-app/frontend/tmp/stub_generator-input_base_path-RWdqCdT1.tmp/frontend/tests/factories/assessment.js
TypeError: Cannot read property 'elements' of undefined
    at findAMDImports (/Users/bryan/dev/betterup-app/frontend/node_modules/ember-browserify/lib/stubs.js:114:6)
```